### PR TITLE
add-tag: Reuse existing tags, and options to add some more.

### DIFF
--- a/ec2snap/ec2snap
+++ b/ec2snap/ec2snap
@@ -24,7 +24,7 @@ import datetime
 import logging
 from collections import OrderedDict
 
-__version__ = 'v0.5.1'
+__version__ = 'v0.5.2'
 
 LVL = {'INFO': logging.INFO,
        'DEBUG': logging.DEBUG,
@@ -128,7 +128,7 @@ class ManageSnapshot:
     """
 
     def __init__(self, region, key_id, access_key, instance_list, tags,
-                 dry_run, timeout, cold_snap, limit, no_root_device,
+                 dry_run, timeout, cold_snap, limit, no_root_device, add_tags,
                  max_age, no_snap, keep_last_snapshots, logger=__name__):
         """
         :param region: EC2 region
@@ -180,6 +180,10 @@ class ManageSnapshot:
         self._access_key = access_key
         self._instance_list = instance_list
         self._tags = tags
+        # receive ["key1:value1", "key2:value2"], transform it to: {key1: value1, key2: value2}
+        self._add_tags = {}
+        if len(add_tags) > 0:
+            self._add_tags = {elem.split(':')[0]: elem.split(':')[1] for elem in add_tags[0]}
         self._dry_run = dry_run
         self._timeout = timeout
         self._cold_snap = cold_snap
@@ -353,10 +357,12 @@ class ManageSnapshot:
             if self._dry_run is False:
                 try:
                     snap_id = self._conn.create_snapshot(vol, snap_name)
-                    snap_id.add_tags({'type': stype,
-                                      'volume': vol,
-                                      'device': device,
-                                      'instance name': iid.name})
+                    tags_objects = self._conn.get_all_tags(filters={'resource_id': vol})
+                    current_tags = {tag.name: tag.value for tag in tags_objects}
+                    if bool(current_tags) is False:
+                        current_tags = {'type': stype, 'volume': vol, 'device': device, 'instance name': iid.name}
+                    tag_list = dict(current_tags, **self._add_tags)
+                    snap_id.add_tags(tag_list)
                 except Exception as e:
                     self.logger.critical("%s snapshot failed for %s(%s) [%s]" %
                                          (stype, vol, device, e))
@@ -576,6 +582,9 @@ def main():
     parser.add_argument('-t', '--tags', action='append', type=str,
                         default=[], metavar='ARG', nargs=2,
                         help='Select tags with values (ex: tagname value)')
+    parser.add_argument('-e', '--add_tags', action='append', type=str,
+                        default=[], metavar='ARG', nargs='*',
+                        help='Tags added to snapshots (ex: tag1:value1 ...')
 
     parser.add_argument('-u', '--dry_run', action='store_false', default=True,
                         help='Define if it should make snapshot or just \
@@ -647,6 +656,12 @@ def main():
             print("Don't have permission to read credentials file")
             sys.exit(1)
 
+    if arg.add_tags is not None and len(arg.add_tags) > 0:
+        for elem in arg.add_tags[0]:
+            if elem.find(':') == -1:
+                print("Tag '%s' has wrong format, missing separator ':'" % elem)
+                sys.exit(1)
+
     # Exit if no instance or tag has been set
     if arg.instance is None and arg.tags is None:
         print('Please set at least instance ID or tag with value')
@@ -657,8 +672,8 @@ def main():
                                             arg.access_key, arg.instance,
                                             arg.tags, arg.dry_run, arg.timeout,
                                             arg.cold_snap, arg.limit,
-                                            arg.no_root_device, arg.max_age,
-                                            arg.no_snap,
+                                            arg.no_root_device, arg.add_tags,
+                                            arg.max_age, arg.no_snap,
                                             arg.keep_last_snapshots)
         # Calculate max snapshot age
         if len(arg.max_age) > 0:


### PR DESCRIPTION
Before the commit only the following tags were set:
{'type': stype, 'volume': vol, 'device': device, 'instance name': iid.name}

Now the snapshot will reuse existing tags of the volumes if it has any, otherwise it will use the previously established ones.
You can also add some more tags with the -e parameter, by providing arguments as such:
-e "tag1:value1" "tag2:value2" etc

The tests (with debug in dry-run):

``` bash
> ./ec2snap -r eu-west-1 -u -i i-67a392ef
2016-06-16 16:14:22,109 [INFO] == Launching run mode ==
2016-06-16 16:14:22,109 [INFO] Connecting to AWS
2016-06-16 16:14:22,110 [INFO] Getting instances information
2016-06-16 16:14:23,127 [INFO] Working on instance i-67a392ef (CYCLOID-METRICS0-EU-WE1-INFRA)
{'volume': u'vol-3a5889ff', 'device': u'/dev/xvda', 'instance name': u'CYCLOID-METRICS0-EU-WE1-INFRA', 'type': 'Hot'}
2016-06-16 16:14:23,690 [INFO] Hot snapshot made for vol-3a5889ff(/dev/xvda) - snap-f301451e
{u'project': u'infra', u'client': u'cycloid', u'role': u'metrics', u'Name': u'METRICS0--EU-WE1-INFRA-EBS', u'env': u'infra'}
2016-06-16 16:14:24,373 [INFO] Hot snapshot made for vol-435b8a86(/dev/xvdf) - snap-d5605238

> ./ec2snap -r eu-west-1 -u -i i-67a392ef -e "e1:value1" "e2:value2" "e3::toto:::"
2016-06-16 16:14:42,909 [INFO] == Launching run mode ==
2016-06-16 16:14:42,909 [INFO] Connecting to AWS
2016-06-16 16:14:42,910 [INFO] Getting instances information
2016-06-16 16:14:44,131 [INFO] Working on instance i-67a392ef (CYCLOID-METRICS0-EU-WE1-INFRA)
{'volume': u'vol-3a5889ff', 'instance name': u'CYCLOID-METRICS0-EU-WE1-INFRA', 'device': u'/dev/xvda', 'e1': 'value1', 'type': 'Hot', 'e3': '', 'e2': 'value2'}
2016-06-16 16:14:44,782 [INFO] Hot snapshot made for vol-3a5889ff(/dev/xvda) - snap-bd268151
{u'Name': u'METRICS0--EU-WE1-INFRA-EBS', u'project': u'infra', u'client': u'cycloid', u'role': u'metrics', u'env': u'infra', 'e1': 'value1', 'e3': '', 'e2': 'value2'}
2016-06-16 16:14:45,594 [INFO] Hot snapshot made for vol-435b8a86(/dev/xvdf) - snap-efb5a303
```
