### PR TITLE
fix time data does not match format

### DIFF
--- a/ec2snap/ec2snap
+++ b/ec2snap/ec2snap
@@ -24,7 +24,7 @@ import datetime
 import logging
 from collections import OrderedDict
 
-__version__ = 'v0.5.3'
+__version__ = 'v0.5.4'
 
 LVL = {'INFO': logging.INFO,
        'DEBUG': logging.DEBUG,
@@ -506,8 +506,7 @@ class ManageSnapshot:
                     snap_date = snapshot.start_time
                 except:
                     return_code = False
-                timestamp = datetime.datetime.strptime(snap_date,
-                                                       '%Y-%m-%dT%H:%M:%S.000Z')
+                timestamp = boto.utils.parse_ts(snap_date)
                 self.logger.debug("Volume %s(%s) has snapshot %s on %s" %
                                   (vol, device, snapshot.id, timestamp))
                 delta_seconds = int((datetime.datetime.utcnow() - timestamp).total_seconds())


### PR DESCRIPTION
https://github.com/cycloidio/ansible-backup-snapshot/issues/1

```
Traceback (most recent call last):
  File "/usr/local/bin/ec2snap", line 726, in <module>
    main()
  File "/usr/local/bin/ec2snap", line 716, in main
    num_mk_err, num_rm_err = selected_instances.mk_rm_snapshot()
  File "/usr/local/bin/ec2snap", line 482, in mk_rm_snapshot
    if not self._remove_old_snap(iid):
  File "/usr/local/bin/ec2snap", line 510, in _remove_old_snap
    '%Y-%m-%dT%H:%M:%S.000Z')
  File "/usr/lib/python2.7/_strptime.py", line 332, in _strptime
    (data_string, format))
ValueError: time data '2019-06-25T10:01:46.574Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
```